### PR TITLE
fix: remove exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,19 @@ func Run(ctx context.Context, app *application.App) {
   }
   
   trace.Tracer("Health-Squad-Worker")
-  
-  ctx, span := trace.StartSpan(ctx, "Health-Squad-Worker", "FetchFitbit")
-  defer span.End()
 
   ...
 
   subscriber := client.Subscription(config.SubscriptionID)
   err = subscriber.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+    ctx, span := trace.StartSpan(ctx, "Health-Squad-Worker", "FetchFitbit")
     ...
   
     ...
   
     log.Info(ctx, log.Fields{"payload": payload}, "user fitbit data fetched successfully")
     msg.Ack()
+	span.End()
   })
   if err != nil {
     log.Error(ctx, err, log.Fields{}, "unable to receive messages")

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -3,24 +3,14 @@ package trace
 import (
 	"context"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 )
 
 func InitTrace(ctx context.Context) error {
-	client := otlptracehttp.NewClient()
-
-	exporter, err := otlptrace.New(ctx, client)
-	if err != nil {
-		return err
-	}
-
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithSyncer(exporter),
 	)
 
 	otel.SetTracerProvider(tp)


### PR DESCRIPTION
This is to remove this kind of error as we don't need exporter for now
<img width="790" alt="image" src="https://github.com/pixel8labs/logtrace/assets/27007722/350adc05-87fc-4b65-92f8-8725e6b04394">

Released and used in this PR for blockoffice https://github.com/pixel8labs/project-blockoffice/pull/306